### PR TITLE
make keys match with lengths and values in KeyedJaggedTensor in movielensDataset

### DIFF
--- a/generative_recommenders/dlrm_v3/datasets/movie_lens.py
+++ b/generative_recommenders/dlrm_v3/datasets/movie_lens.py
@@ -131,7 +131,6 @@ class DLRMv3MovieLensDataset(DLRMv3RandomDataset):
                 for _ in range(
                     len(self._uih_keys)
                     - len(self._contextual_feature_to_max_length)
-                    - 1
                 )
             ]
         )
@@ -140,7 +139,7 @@ class DLRMv3MovieLensDataset(DLRMv3RandomDataset):
         uih_kjt_values.append(dummy_query_time)
         uih_kjt_lengths.append(1)
         uih_features_kjt = KeyedJaggedTensor(
-            keys=self._uih_keys,
+            keys=self._uih_keys + ["dummy_query_time"],
             lengths=torch.tensor(uih_kjt_lengths).long(),
             values=torch.tensor(uih_kjt_values).long(),
         )


### PR DESCRIPTION
In movielens dataset, the keys don't match with lengths and values in KeyedJaggedTensor though inference can run successfully. However, the underlying reordered data is completely messed up. This PR is the simple change to fix the issue.

Here is data with 2 samples from movielens-20m. Each has sequence length of 16. They are 7 columns/features. The current lengths of each features are shown as below. Apparently, the length (16) of the second to last feature (dummy watch time) is missing.

||user id|movie_history|ratings|timestamp|dummy weight|dummy watch time|query time|
|---|:---:|---:|---:|---|:---:|---:|---:|
|sample 1 lengths|1|16|16|16|16|1||
|sample 2 lengths|1|16|16|16|16|1||

The correct lengths should be, 

||user id|movie_history|ratings|timestamp|dummy weight|dummy watch time|query time|
|---|:---:|---:|---:|---|:---:|---:|---:|
|sample 1 lengths|1|16|16|16|16|16|1|
|sample 2 lengths|1|16|16|16|16|16|1|


Samples data:

tensor([     14400,       2890,         31,        277,        585,       2105,
              2294,        252,       1262,       3911,       2455,       3255,
              1022,       1287,       1271,       1343,       2150,          5,
                 3,          3,          3,          3,          3,          5,
                 3,          2,          2,          4,          3,          3,
                 4,          3,          3, 1368001664, 1368001664, 1368001792,
        1368001792, 1368001792, 1368001792, 1368001792, 1368001792, 1368001792,
        1368001792, 1368001792, 1368001792, 1368001792, 1368001792, 1368001792,
        1368001792,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0, 1368001792,      97042,       1721,
              2735,       3785,        110,       2628,       1210,       3248,
               880,        527,        410,       2571,       4226,       3996,
              1136,       1240,       1285,          3,          3,          3,
                 4,          3,          4,          3,          4,          5,
                 4,          5,          5,          5,          5,          2,
                 3, 1007606336, 1007606336, 1007606400, 1007606400, 1007606400,
        1007606400, 1007606464, 1007606464, 1007606464, 1007606464, 1007606528,
        1007606528, 1007606528, 1007606528, 1007606528, 1007606528,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0, 1007606528])

After reordering in kjt_batch_func , before the fix:

tensor([              14400,                   0,                2890,
                         31,                 277,                 585,
                       2105,                2294,                 252,
                       1262,                3911,                2455,
                       3255,                1022,                1287,
                       1271,                1343,                2150,
                          0,                   0,                   0,
                          0,                   0,                   0,
                          0,                   0,                   0,
                          0,                   0,                   0,
                          0,                   0,          1368001792,
                      97042,                   5,                   3,
                          3,                   3,                   3,
                          3,                   5,                   3,
                          2,                   2,                   4,
                          3,                   3,                   4,
                          3,                   3,                1721,
                       2735,                3785,                 110,
                       2628,                1210,                3248,
                        880,                 527,                 410,
                       2571,                4226,                3996,
                       1136,                1240,                1285,
                 1368001664,          1368001664,          1368001792,
                 1368001792,          1368001792,          1368001792,
                 1368001792,          1368001792,          1368001792,
                 1368001792,          1368001792,          1368001792,
                 1368001792,          1368001792,          1368001792,
                 1368001792,                   3,                   3,
                          3,                   4,                   3,
                          4,                   3,                   4,
                          5,                   4,                   5,
                          5,                   5,                   5,
                          2,                   3,                   0,
                          0,                   0,                   0,
                          0,                   0,                   0,
                          0,                   0,                   0,
                          0,                   0,                   0,
                          0,                   0,                   0,
                 1007606336,          1007606336,          1007606400,
                 1007606400,          1007606400,          1007606400,
                 1007606464,          1007606464,          1007606464,
                 1007606464,          1007606528,          1007606528,
                 1007606528,          1007606528,          1007606528,
                 1007606528,                   0,                   0,
        2314885531020828704, 3184080258900959264, 2314885530818453536,
        2314885531020828704, 3184080258900959264, 2314885530818473564,
        2314885530818453536, 2314885582626496544, 3467807035425300512,
        2314885530818453548, 2314885582626496544, 3467807035425300512,
        2314885530818453548, 2314885582626496544, 3467807035425300512,
        2314885530823580716, 2314885530818453536, 2314898793677463584,
        2314885530818453536, 2314885530818456624, 3539877892322238496,
        4122818066918159923, 2314885530818456626, 2314898802603996985,
        3618414839663173664, 2314885532131011633, 2314885530818453536,
        2318286402274598944, 3977558218248298528, 2314885530819245368,
        2318280896024682528, 3905219149233659936])

After reordering in kjt_batch_func , after the fix:

tensor([     14400,      97042,       2890,         31,        277,        585,
              2105,       2294,        252,       1262,       3911,       2455,
              3255,       1022,       1287,       1271,       1343,       2150,
              1721,       2735,       3785,        110,       2628,       1210,
              3248,        880,        527,        410,       2571,       4226,
              3996,       1136,       1240,       1285,          5,          3,
                 3,          3,          3,          3,          5,          3,
                 2,          2,          4,          3,          3,          4,
                 3,          3,          3,          3,          3,          4,
                 3,          4,          3,          4,          5,          4,
                 5,          5,          5,          5,          2,          3,
        1368001664, 1368001664, 1368001792, 1368001792, 1368001792, 1368001792,
        1368001792, 1368001792, 1368001792, 1368001792, 1368001792, 1368001792,
        1368001792, 1368001792, 1368001792, 1368001792, 1007606336, 1007606336,
        1007606400, 1007606400, 1007606400, 1007606400, 1007606464, 1007606464,
        1007606464, 1007606464, 1007606528, 1007606528, 1007606528, 1007606528,
        1007606528, 1007606528,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
                 0,          0,          0,          0,          0,          0,
        1368001792, 1007606528])
