### PR TITLE
remove embedding collections from dense module in dlrm v3

### DIFF
--- a/generative_recommenders/dlrm_v3/inference/inference_modules.py
+++ b/generative_recommenders/dlrm_v3/inference/inference_modules.py
@@ -41,6 +41,7 @@ def get_hstu_model(
     hstu_config: DlrmHSTUConfig,
     table_device: str = "meta",
     max_hash_size: Optional[int] = None,
+    is_dense: bool = False,
 ) -> DlrmHSTU:
     if max_hash_size is not None:
         for t in table_config.values():
@@ -51,6 +52,7 @@ def get_hstu_model(
         hstu_configs=hstu_config,
         embedding_tables=table_config,
         is_inference=IS_INFERENCE,
+        is_dense=is_dense
     )
     model.eval()
     model.recursive_setattr("_use_triton_cc", False)

--- a/generative_recommenders/dlrm_v3/inference/model_family.py
+++ b/generative_recommenders/dlrm_v3/inference/model_family.py
@@ -228,6 +228,7 @@ class ModelFamilyDenseDist:
             hstu_config=self.hstu_config,
             table_device="cpu",
             max_hash_size=100,
+            is_dense=True
         )
         load_nonsparse_checkpoint(model=model, optimizer=None, path=model_path)
 
@@ -380,6 +381,7 @@ class ModelFamilyDenseSingleWorker:
             table_config=self.table_config,
             hstu_config=self.hstu_config,
             table_device="cpu",
+            is_dense=True
         ).to(self.device)
         load_nonsparse_checkpoint(model=self.model, optimizer=None, path=model_path)
         assert self.model is not None

--- a/generative_recommenders/modules/dlrm_hstu.py
+++ b/generative_recommenders/modules/dlrm_hstu.py
@@ -123,17 +123,19 @@ class DlrmHSTU(HammerModule):
         hstu_configs: DlrmHSTUConfig,
         embedding_tables: Dict[str, EmbeddingConfig],
         is_inference: bool,
+        is_dense: bool
     ) -> None:
         super().__init__(is_inference=is_inference)
         logger.info(f"Initialize HSTU module with configs {hstu_configs}")
         self._hstu_configs = hstu_configs
         set_static_max_seq_lens([self._hstu_configs.max_seq_len])
 
-        self._embedding_collection = EmbeddingCollection(
-            tables=list(embedding_tables.values()),
-            need_indices=False,
-            device=torch.device("meta"),
-        )
+        if not is_dense:
+            self._embedding_collection = EmbeddingCollection(
+                tables=list(embedding_tables.values()),
+                need_indices=False,
+                device=torch.device("meta"),
+            )
 
         # multitask configs must be sorted by task types
         self._multitask_configs: List[TaskConfig] = hstu_configs.multitask_configs


### PR DESCRIPTION
The embeddings processing inside DlrmHSTU is only in sparse module in dlrm v3. The same embeddings get instantiated and moved to GPU/XPU in dense module since DlrmHSTU is shared between sparse module and dense module. However, the embeddings are never used in dense module and it's usually bigger enough, e.g, 10GB for movielens dataset. Thus, we should remove it from dense module.